### PR TITLE
Save menu and save file handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PREFIX ?= .
 BINDIR = ${PREFIX}/bin
 LIBDIR = ${PREFIX}/share/omega
 # the value of SAVEDIR should be the same as SAVEDIR in defs.h
-SAVEDIR = "${LIBDIR}/saves"
+SAVEDIR = ${LIBDIR}/saves
 
 # One of these should be uncommented, as appropriate, unless your compiler
 # does it for you.  You can test this by simply trying to 'make' omega -

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ PREFIX ?= .
 # the value of LIBDIR should be the same as OMEGALIB in defs.h
 BINDIR = ${PREFIX}/bin
 LIBDIR = ${PREFIX}/share/omega
+# the value of SAVEDIR should be the same as SAVEDIR in defs.h
+SAVEDIR = "${LIBDIR}/saves"
 
 # One of these should be uncommented, as appropriate, unless your compiler
 # does it for you.  You can test this by simply trying to 'make' omega -
@@ -20,6 +22,7 @@ CFLAGS += \
   -fno-strict-aliasing  \
   -DBSD \
   -DOMEGALIB=\"${LIBDIR}/\"  \
+  -DSAVEDIR=\"${SAVEDIR}/\" \
   -Wl,-rpath=/usr/local/lib
 
 #CFLAGS = -DSYSV -O
@@ -64,6 +67,7 @@ omega: $(OBJ)
 install: omega
 	mkdir -p $(BINDIR)
 	mkdir -p $(LIBDIR)
+	mkdir -p $(SAVEDIR)
 	chown games:games omega
 	cp omega $(BINDIR)
 	chmod 4711 $(BINDIR)/omega

--- a/aux1.c
+++ b/aux1.c
@@ -512,6 +512,15 @@ char *fromstring;
   dataprint();
 }
 
+/* get save filename */
+void gen_save_fname(save_file)
+char *save_file;
+{
+  strcpy(save_file, SAVEDIR);
+  strcat(save_file, Player.name);
+  strcat(save_file, ".sav");
+}
+
 /* game over, you lose! */
 void p_death(fromstring)
 char *fromstring;
@@ -527,9 +536,7 @@ char *fromstring;
 #endif
   endgraf();
 
-  strcpy(savestr, SAVEDIR);
-  strcat(savestr, Player.name);
-  strcat(savestr, ".sav");
+  gen_save_fname(savestr);
   change_to_user_perms();
   unlink(savestr);
   change_to_game_perms(); // is this necessary?

--- a/aux1.c
+++ b/aux1.c
@@ -516,6 +516,8 @@ char *fromstring;
 void p_death(fromstring)
 char *fromstring;
 {
+  char savestr[84];
+
   Player.hp = -1;
   print3("You died!");
   morewait();
@@ -524,6 +526,13 @@ char *fromstring;
   kill_all_levels();
 #endif
   endgraf();
+
+  strcpy(savestr, SAVEDIR);
+  strcat(savestr, Player.name);
+  strcat(savestr, ".sav");
+  change_to_user_perms();
+  unlink(savestr);
+  change_to_game_perms(); // is this necessary?
   exit(0);
 }
 

--- a/command2.c
+++ b/command2.c
@@ -974,13 +974,7 @@ int compress, force;
     ok = (ynq1() == 'y');
   }
   if (force || ok) {
-    strcpy(fname, SAVEDIR);
-    strcat(fname, Player.name);
-    strcat(fname, ".sav");
-    if (fname[0] == '\0') {
-      print1("No save file entered - save aborted.");
-      ok = FALSE;
-    }
+    gen_save_fname(fname)
 #ifdef MSDOS
     for (pos = 0; fname[pos] && isalnum(fname[pos]); pos++)
       ;

--- a/command2.c
+++ b/command2.c
@@ -974,7 +974,7 @@ int compress, force;
     ok = (ynq1() == 'y');
   }
   if (force || ok) {
-    gen_save_fname(fname)
+    gen_save_fname(fname);
 #ifdef MSDOS
     for (pos = 0; fname[pos] && isalnum(fname[pos]); pos++)
       ;

--- a/command2.c
+++ b/command2.c
@@ -974,8 +974,9 @@ int compress, force;
     ok = (ynq1() == 'y');
   }
   if (force || ok) {
-    print1("Enter savefile name: ");
-    strcpy(fname,msgscanstring());
+    strcpy(fname, SAVEDIR);
+    strcat(fname, Player.name);
+    strcat(fname, ".sav");
     if (fname[0] == '\0') {
       print1("No save file entered - save aborted.");
       ok = FALSE;

--- a/defs.h
+++ b/defs.h
@@ -49,6 +49,12 @@ on save and restore. */
 #define OMEGALIB "./lib/"
 #endif
 
+/* SAVEDIR is where saves are kept. Format same as OMEGALIB */
+
+#ifndef SAVEDIR
+#define SAVEDIR "./saves/"
+#endif
+
 /* Comment the following line out if you want users to be able to override */
 /* the OMEGALIB define, above, by setting the environment variable OMEGALIB */
 /* (I recommend leaving this line uncommented, unless you're compiling */

--- a/extern.h
+++ b/extern.h
@@ -10,6 +10,7 @@
 /* omega.c functions */
 
 int main ARGS((int,char *[]));
+int load_save_games ARGS((void));
 int game_restore ARGS((int,char *[]));
 void init_world ARGS((void));
 void inititem ARGS((int));

--- a/extern.h
+++ b/extern.h
@@ -10,6 +10,7 @@
 /* omega.c functions */
 
 int main ARGS((int,char *[]));
+void gen_save_fname(char *);
 int load_save_games ARGS((void));
 int game_restore ARGS((int,char *[]));
 void init_world ARGS((void));

--- a/extern.h
+++ b/extern.h
@@ -10,7 +10,7 @@
 /* omega.c functions */
 
 int main ARGS((int,char *[]));
-void gen_save_fname(char *);
+void gen_save_fname ARGS((char *));
 int load_save_games ARGS((void));
 int game_restore ARGS((int,char *[]));
 void init_world ARGS((void));

--- a/omega.c
+++ b/omega.c
@@ -201,7 +201,7 @@ int load_save_games(void)
   int ok; char response;
   char savestr[80];
 
-  int max_saves=10, pname_length=84; // max Player.name length + .sav
+  int max_saves=15, pname_length=84; // max Player.name length + .sav
   char *savegames[max_saves][pname_length];
 
   int n=0; struct dirent *d; DIR *dir;
@@ -351,7 +351,6 @@ char *argv[];
 
   /* game restore attempts to restore game if there is an argument */
   continuing = load_save_games();
-  //continuing = game_restore(argc,argv);
 
   /* monsters initialized in game_restore if game is being restored */  
   /* items initialized in game_restore if game is being restored */

--- a/omega.c
+++ b/omega.c
@@ -211,7 +211,8 @@ int load_save_games(void)
     else if ((strcmp(d->d_name, "..")) == 0) { continue; }
     strcpy(savegames[n], d->d_name); 
     if (n++ >= max_saves) { break; }
-  }
+  } closedir(dir);
+
   printw("%s\n", "Please select a save or type (n) for new game:");
   if (n < 1) { return 0; }
   for (int i=0; i<n; i++) {

--- a/omega.c
+++ b/omega.c
@@ -9,6 +9,7 @@
 #include <time.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <dirent.h>
 /* Note: in order to avoid a memory bug I've been told about, I'm
    explicitly initializing every global to something. */
 #endif
@@ -195,6 +196,42 @@ void initrand(int environment, int level)
   SRANDFUNCTION(seed);
 }
 
+int load_save_games(void)
+{
+  int ok; char response;
+  char savestr[80];
+
+  int max_saves=10, pname_length=84; // max Player.name length + .sav
+  char *savegames[max_saves][pname_length];
+
+  int n=0; struct dirent *d; DIR *dir;
+  if ((dir = opendir(SAVEDIR)) == NULL) { return 0; }
+  while ((d = readdir(dir)) != NULL) {
+    if ((strcmp(d->d_name, ".")) == 0) { continue; }
+    else if ((strcmp(d->d_name, "..")) == 0) { continue; }
+    strcpy(savegames[n], d->d_name); 
+    if (n++ >= max_saves) { break; }
+  }
+  printw("%s\n", "Please select a save or type (n) for new game:");
+  if (n < 1) { return 0; }
+  for (int i=0; i<n; i++) {
+    printw("%c: %s\n", i+'a', savegames[i]);
+  }
+  refresh();
+
+  do response = (char) mcigetc(); while (((response < 'a') || (response >= 'a'+n)) && (response != 'n'));
+  clear_screen();
+  if (response == 'n') { return 0; }
+  strcpy(savestr, SAVEDIR);
+  strcat(savestr, savegames[response-'a']);
+  ok = restore_game(savestr);
+  if (! ok) {
+    endgraf();
+    printf("Try again with the right save file, luser!\n");
+    exit(0);
+  }
+  return ok;
+}
 
 int game_restore(argc,argv)
 int argc;
@@ -312,7 +349,8 @@ char *argv[];
   showscores();
 
   /* game restore attempts to restore game if there is an argument */
-  continuing = game_restore(argc,argv);
+  continuing = load_save_games();
+  //continuing = game_restore(argc,argv);
 
   /* monsters initialized in game_restore if game is being restored */  
   /* items initialized in game_restore if game is being restored */


### PR DESCRIPTION
Uses SAVEDIR location for saves, defined at compile time. Saves automatically named by Player name + .sav extension. Saves no longer deleted on load (to prevent loss for d/c or crash), only death. Added save menu for save selection rather than reading save file as arg. Save menu shows up to 15 saves at a time.