### PR TITLE
Force capital Y/N/Q for option selection

### DIFF
--- a/aux1.c
+++ b/aux1.c
@@ -809,7 +809,7 @@ struct monster *m;
     if (m_statusp(m,HOSTILE))
       monster_talk(m);
     else {
-      print2("The guard (bored): Have you broken a law? [yn] ");
+      print2("The guard (bored): Have you broken a law? [YN] ");
       if (ynq2() == 'y') {
 	print2("The guard grabs you, and drags you to court.");
 	morewait();

--- a/char.c
+++ b/char.c
@@ -97,11 +97,11 @@ FILE *omegarc_check()
   FILE *fd;
 #if defined(MSDOS) || defined(AMIGA)
   if ((fd = fopen("omega.rc","rb")) != NULL) {
-    print2("Use omega.rc charcter record in current directory? [yn] ");
+    print2("Use omega.rc charcter record in current directory? [YN] ");
 #else
   sprintf(Str1, "%s/.omegarc", getenv("HOME"));
   if ((fd = fopen(Str1,"r")) != NULL) {
-    print2("Use .omegarc in home directory? [yn] ");
+    print2("Use .omegarc in home directory? [YN] ");
 #endif
     if (ynq2()!='y') {
       fclose(fd);
@@ -122,9 +122,9 @@ void initstats()
     user_character_stats();
     user_intro();
 #if defined(MSDOS) || defined(AMIGA)
-    print1("Do you want to save this set-up to omega.rc in this directory? [yn] ");
+    print1("Do you want to save this set-up to omega.rc in this directory? [YN] ");
 #else
-    print1("Do you want to save this set-up to .omegarc in your home directory? [yn] ");
+    print1("Do you want to save this set-up to .omegarc in your home directory? [YN] ");
 #endif
     if (ynq1()=='y')
       save_omegarc();
@@ -300,7 +300,7 @@ void user_character_stats()
     Player.str = Player.maxstr = 18;
   }
   
-  print1("Took an official IQ test? [yn] ");
+  print1("Took an official IQ test? [YN] ");
   if (ynq1()=='y') {
     print1("So, whadja get? ");
     num = (int) parsenum()/10;
@@ -314,7 +314,7 @@ void user_character_stats()
     numints++;
   }
 
-  print1("Took Undergraduate entrance exams? [yn] ");
+  print1("Took Undergraduate entrance exams? [YN] ");
   if (ynq1()=='y') {
     do {
       print1("So, what percentile? ");
@@ -329,7 +329,7 @@ void user_character_stats()
     iqpts += (num - 49)*9/50 + 9;
     numints++;
   }
-  print1("Took Graduate entrance exams? [yn] ");
+  print1("Took Graduate entrance exams? [YN] ");
   if (ynq1()=='y') {
     do {
       print1("So, what percentile? ");
@@ -346,7 +346,7 @@ void user_character_stats()
   }
 
   if (numints == 0) {
-    print1("Pretty dumb, aren't you? [yn] ");
+    print1("Pretty dumb, aren't you? [YN] ");
     if (ynq1()=='y') {
       Player.iq = random_range(3)+3;      
       print2("I thought so....");
@@ -361,59 +361,59 @@ void user_character_stats()
   else Player.iq = iqpts/numints;
   Player.maxiq = Player.iq;
   agipts = 0;
-  print1("Can you dance? [yn] ");
+  print1("Can you dance? [YN] ");
   if (ynq1()=='y') {
     agipts++;
-    nprint1(" Well? [yn] ");
+    nprint1(" Well? [YN] ");
     if (ynq1()=='y') agipts+=2;
   }
-  print1("Do you have training in a martial art or gymnastics? [yn] ");
+  print1("Do you have training in a martial art or gymnastics? [YN] ");
   if (ynq1()=='y') {
     agipts+=2;
-    print2("Do you have dan rank or equivalent? [yn] ");
+    print2("Do you have dan rank or equivalent? [YN] ");
     if (ynq2()=='y') agipts+=4;
   }
   clearmsg();
-  print1("Do you play some field sport? [yn] ");
+  print1("Do you play some field sport? [YN] ");
   if (ynq1()=='y') {
     agipts++;
-    nprint1(" Are you good? [yn] ");
+    nprint1(" Are you good? [YN] ");
     if (ynq1()=='y') agipts++;
   }
-  print1("Do you cave, mountaineer, etc.? [yn] ");
+  print1("Do you cave, mountaineer, etc.? [YN] ");
   if (ynq1()=='y')
     agipts+=3;
-  print1("Do you skate or ski? [yn] ");
+  print1("Do you skate or ski? [YN] ");
   if (ynq1()=='y') {
     agipts+=2;
-    nprint1(" Well? [yn] ");
+    nprint1(" Well? [YN] ");
     if (ynq1()=='y') agipts+=2;
   }
-  print1("Are you physically handicapped? [yn] ");
+  print1("Are you physically handicapped? [YN] ");
   if (ynq1()=='y')
     agipts-=4;
-  print1("Are you accident prone? [yn] ");
+  print1("Are you accident prone? [YN] ");
   if (ynq1()=='y')
     agipts-=4;
-  print1("Can you use a bicycle? [yn] ");
+  print1("Can you use a bicycle? [YN] ");
   if (ynq1()!='y')
     agipts-=4;
   Player.agi = Player.maxagi = 9 + agipts/2;
-  print1("Do you play video games? [yn] ");
+  print1("Do you play video games? [YN] ");
   if (ynq1()=='y') {
     dexpts+=2;
-    print2("Do you get high scores? [yn] ");
+    print2("Do you get high scores? [YN] ");
     if (ynq2()=='y') dexpts+=4;
   }
   clearmsg();
-  print1("Are you an archer, fencer, or marksman? [yn] ");
+  print1("Are you an archer, fencer, or marksman? [YN] ");
   if (ynq1()=='y') {
     dexpts+=2;
-    print2("A good one? [yn] ");
+    print2("A good one? [YN] ");
     if (ynq2()=='y') dexpts+=4;
   }
   clearmsg();
-  print1("Have you ever picked a lock? [yn] ");
+  print1("Have you ever picked a lock? [YN] ");
   if (ynq1()=='y') {
     dexpts+=2;
     print2("Really. Well, the police are being notified.");
@@ -429,38 +429,38 @@ void user_character_stats()
     num = 125;
   }
   dexpts += num/25;
-  print1("Hold your arm out. Tense your fist. Hand shaking? [yn] ");
+  print1("Hold your arm out. Tense your fist. Hand shaking? [YN] ");
   if (ynq1()=='y')
     dexpts-=3;
-  print1("Ambidextrous, are you? [yn] ");
+  print1("Ambidextrous, are you? [YN] ");
   if (ynq1()=='y')
     dexpts+=4;
-  print1("Can you cut a deck of cards with one hand? [yn] ");
+  print1("Can you cut a deck of cards with one hand? [YN] ");
   if (ynq1()=='y')
     dexpts+=2;
-  print1("Can you tie your shoes blindfolded? [yn] ");
+  print1("Can you tie your shoes blindfolded? [YN] ");
   if (ynq1()!='y')
     dexpts-=3;
   Player.dex = Player.maxdex = 6 + dexpts/2;
-  print1("Do you ever get colds? [yn] ");
+  print1("Do you ever get colds? [YN] ");
   if (ynq1()!='y') 
     conpts+=4;
   else {
-    nprint1(" Frequently? [yn] ");
+    nprint1(" Frequently? [YN] ");
     if (ynq1() == 'y') conpts -=4;
   }
-  print1("Had any serious accident or illness this year? [yn] ");
+  print1("Had any serious accident or illness this year? [YN] ");
   if (ynq1()=='y') conpts -=4;
   else conpts +=4;
-  print1("Have a chronic disease? [yn] ");
+  print1("Have a chronic disease? [YN] ");
   if (ynq1() =='y') conpts -=4;
-  print1("Overweight or underweight by more than 20 percent? [yn] ");
+  print1("Overweight or underweight by more than 20 percent? [YN] ");
   if (ynq1() =='y') conpts -=2;
-  print1("High Blood Pressure? [yn] ");
+  print1("High Blood Pressure? [YN] ");
   if (ynq1() =='y') conpts -=2;
-  print1("Smoke? [yn] ");
+  print1("Smoke? [YN] ");
   if (ynq1() =='y') conpts -=3;
-  print1("Take aerobics classes? [yn] ");
+  print1("Take aerobics classes? [YN] ");
   if (ynq1() =='y') conpts +=2;
   print1("How many miles can you run? ");
   num = (int) parsenum();
@@ -475,30 +475,30 @@ void user_character_stats()
   else if (num < 10) conpts += 4;
   else conpts += 8;
   Player.con = Player.maxcon = 12 + conpts/3;
-  print1("Do animals react oddly to your presence? [yn] ");
+  print1("Do animals react oddly to your presence? [YN] ");
   if (ynq1()=='y') {
     print2("How curious that must be.");
     morewait();
     clearmsg();
     powpts += 2;
   }
-  print1("Can you see auras? [yn] ");
+  print1("Can you see auras? [YN] ");
   if (ynq1()=='y') {
     nprint1(" How strange.");
     morewait();
     powpts += 3;
   }
-  print1("Ever have an out-of-body experience? [yn] ");
+  print1("Ever have an out-of-body experience? [YN] ");
   if (ynq1()=='y') {
     print2("Wow, man. Fly the friendly skies....");
     morewait();
     clearmsg();
     powpts += 3;
   }
-  print1("Did you ever cast a spell? [yn] ");
+  print1("Did you ever cast a spell? [YN] ");
   if (ynq1()=='y') {
     powpts += 3;
-    nprint1(" Did it work? [yn] ");
+    nprint1(" Did it work? [YN] ");
     if (ynq1()=='y') {
       powpts+=7;
       print2("Sure it did.");
@@ -506,28 +506,28 @@ void user_character_stats()
       clearmsg();
     }
   }
-  print1("Do you have ESP? [yn] ");
+  print1("Do you have ESP? [YN] ");
   if (ynq1()=='y') {
     powpts += 3;
     print2("Somehow, I knew you were going to say that.");
     morewait();
     clearmsg();
   }
-  print1("Do you have PK? [yn] ");
+  print1("Do you have PK? [YN] ");
   if (ynq1()=='y') {
     powpts+= 6;
     print2("I can't tell you how much that moves me.");
     morewait();
     clearmsg();
   }
-  print1("Do you believe in ghosts? [yn] ");
+  print1("Do you believe in ghosts? [YN] ");
   if (ynq1()=='y') {
     powpts+=2;
     print2("I do! I do! I do believe in ghosts!");
     morewait();
     clearmsg();
   }
-  print1("Are you Irish? [yn] ");
+  print1("Are you Irish? [YN] ");
   if (ynq1()=='y') {
     powpts+=2;
     nprint1(" Is that blarney or what?");

--- a/command2.c
+++ b/command2.c
@@ -688,7 +688,7 @@ void callitem()
       print1("Call it:");
       obj->objstr = salloc(msgscanstring());
       clearmsg();
-      print2("Also call all similar items by that name? [yn] ");
+      print2("Also call all similar items by that name? [YN] ");
       if (ynq2() == 'y') {
 	Objects[obj->id].objstr = obj->objstr;
       }
@@ -765,7 +765,7 @@ void bash_location()
       print1("Back Door WIZARD Mode!");
       print2("You will invalidate your score if you proceed.");
       morewait();
-      print1("Enable WIZARD Mode? [yn] ");
+      print1("Enable WIZARD Mode? [YN] ");
       if (ynq1()=='y') {
 	print2("You feel like a cheater.");
 	setgamestatus(CHEATED);
@@ -970,7 +970,7 @@ int compress, force;
     }
   }
   if (!force && ok) {
-    print1("Confirm Save? [yn] ");
+    print1("Confirm Save? [YN] ");
     ok = (ynq1() == 'y');
   }
   if (force || ok) {

--- a/command3.c
+++ b/command3.c
@@ -276,7 +276,7 @@ void quit()
 {
   clearmsg();
   change_to_game_perms();
-  mprint("Quit: Are you sure? [yn] ");
+  mprint("Quit: Are you sure? [YN] ");
   if (ynq()=='y') {
     if (Player.rank[ADEPT] == 0) display_quit();
     else display_bigwin();
@@ -472,7 +472,7 @@ void wizard()
   if (gamestatusp(CHEATED)) mprint("You're already in wizard mode!");
   else {
     clearmsg();
-    mprint("Really try to enter wizard mode? [yn] ");
+    mprint("Really try to enter wizard mode? [YN] ");
     if (ynq()=='y') {
        lname = getlogin();
 #ifndef MSDOS_SUPPORTED_ANTIQUE
@@ -981,7 +981,7 @@ void dismount_steed()
     print3("You're on foot already!");
   else if (Current_Environment == E_COUNTRYSIDE) {
     mprint("If you leave your steed here he will wander away!");
-    mprint("Do it anyway? [yn] ");
+    mprint("Do it anyway? [YN] ");
     if (ynq()=='y') resetgamestatus(MOUNTED);
   }
   else {

--- a/file.c
+++ b/file.c
@@ -554,7 +554,7 @@ int filecheck()
     }
     else if (badbutpossible) {
 	printf("\nFurther execution may cause anomalous behavior.");
-	printf("\nContinue anyhow? [yn] ");
+	printf("\nContinue anyhow? [YN] ");
 	if (getchar()=='y') return(-1);
 	else return(0);
     }

--- a/guild1.c
+++ b/guild1.c
@@ -31,7 +31,7 @@ void l_merc_guild()
     case 0:
       nprint2("and see the Recruiting Centurion.");
       morewait();
-      print2("Do you wish to join the Legion? [yn] ");
+      print2("Do you wish to join the Legion? [YN] ");
       if (ynq2()=='y') {
 	clearmsg();
 	if (Player.rank[ARENA]>0) {
@@ -207,7 +207,7 @@ void l_castle()
       clearmsg();
     }
     if (Player.rank[NOBILITY]==0) {
-      print1("Well, sirrah, wouldst embark on a quest? [yn] ");
+      print1("Well, sirrah, wouldst embark on a quest? [YN] ");
       if (ynq1() == 'y') {
 	print2("Splendid. Bring me the head of the Goblin King.");
 	Player.rank[NOBILITY]=COMMONER;
@@ -311,7 +311,7 @@ void l_arena()
     while ((response != 'e') && (response != 'r') && (response != ESCAPE));
   }
   else {
-    print2("Enter the games? [yn] ");
+    print2("Enter the games? [YN] ");
     response = ynq2();
     if (response == 'y') response = 'e';
     else response = ESCAPE;

--- a/guild2.c
+++ b/guild2.c
@@ -69,7 +69,7 @@ void l_thieves_guild()
 	  clearmsg();
 	  mprint("Dues are");
 	  mnumprint(dues);
-	  mprint(" Au. Pay it? [yn] ");
+	  mprint(" Au. Pay it? [YN] ");
 	  if (ynq1() =='y') {
 	    if (Player.cash < dues) {
 	      print1("You can't cheat the Thieves' Guild!");
@@ -185,7 +185,7 @@ void l_thieves_guild()
 	  clearmsg();
 	  print1("The fee will be: ");
 	  mnumprint(max(count*fee,fee));
-	  nprint1("Au. Pay it? [yn] ");
+	  nprint1("Au. Pay it? [YN] ");
 	  if (ynq1()=='y')
 	  if (Player.cash < max(count*fee,fee))
 	    print2("Try again when you have the cash.");
@@ -211,7 +211,7 @@ void l_thieves_guild()
 	      clearmsg();
 	      print1("I'll give you ");
 	      mlongprint(2 * item_value(Player.possessions[i]) / 3);
-	      nprint1("Au each. OK? [yn] ");
+	      nprint1("Au each. OK? [YN] ");
 	      if (ynq1() == 'y') {
 		number = getnumber(Player.possessions[i]->number);
 		if ((number >= Player.possessions[i]->number) &&
@@ -238,7 +238,7 @@ void l_thieves_guild()
 		nprint1(itemid(Player.pack[i]));
 		nprint1(" for ");
 		mlongprint(2*item_value(Player.pack[i])/3);
-		nprint1("Au each? [ynq] ");
+		nprint1("Au each? [YNQ] ");
 		if ((c=ynq1())=='y') {
 		  number = getnumber(Player.pack[i]->number);
 		  Player.cash += 2*number * item_value(Player.pack[i]) / 3;
@@ -317,7 +317,7 @@ void l_college()
 	  }
 	  else {
 	    print1("Tuition is 1000Au. ");
-	    nprint1("Pay it? [yn] ");
+	    nprint1("Pay it? [YN] ");
 	    if (ynq1() =='y') {
 	      if (Player.cash < 1000)
 		print2("You don't have the funds!");
@@ -424,7 +424,7 @@ void l_college()
 	}
 	if (Spellsleft < 1) {
 	  print1("Extracurricular Lab fee: 2000 Au. ");
-	  nprint1("Pay it? [yn] ");
+	  nprint1("Pay it? [YN] ");
 	  if (ynq1()=='y') {
 	    if (Player.cash < 2000) 
 	      print1("Try again when you have the cash.");
@@ -504,7 +504,7 @@ void l_sorcerors()
 	mprint("For you, there is an initiation fee of");
 	mnumprint(fee);
 	mprint(" Au.");
-	print2("Pay it? [yn] ");
+	print2("Pay it? [YN] ");
 	if (ynq2() =='y') {
 	  if (Player.cash < fee) 
 	    print3("Try again when you have the cash!");
@@ -605,7 +605,7 @@ void l_sorcerors()
       clearmsg();
       print1("That will be: ");
       mnumprint(fee);
-      nprint1("Au. Pay it? [yn] ");
+      nprint1("Au. Pay it? [YN] ");
       if (ynq1()=='y') {
 	if (Player.cash < fee) 
 	  print2("Begone, deadbeat, or face the wrath of the Circle!");
@@ -688,7 +688,7 @@ void l_order()
     else if (Player.rank[LEGION] != 0) 
       print1("Go back to your barracks, mercenary!");
     else {
-      print1("Dost thou wish to join our Order? [yn] ");
+      print1("Dost thou wish to join our Order? [YN] ");
       if (ynq1()=='y') {
 	print1("Justiciar ");
 	nprint1(Justiciar);

--- a/inv.c
+++ b/inv.c
@@ -90,7 +90,7 @@ int x,y;
       clearmsg1();
       print1("Pick up: ");
       nprint1(itemid(ol->thing));
-      nprint1(" [ynq]: ");
+      nprint1(" [YNQ]: ");
       response = ynq1();
       quit = (response == 'q');
     }

--- a/itemf3.c
+++ b/itemf3.c
@@ -37,7 +37,7 @@ pob o;
   else {
     HiMagicUse = Date;
     print1("With a shriek of tearing aether, a magic portal appears!");
-    print2("Step through? [yn] ");
+    print2("Step through? [YN] ");
     if (ynq()=='y') change_environment(E_COURT);
     print1("The sceptre seems to subside. You hear a high whine, as of");
     print2("capacitors beginning to recharge.");

--- a/move.c
+++ b/move.c
@@ -520,12 +520,12 @@ void l_fire_station()
     print2("You feel the terrible heat despite your immunity to fire!");
     morewait();
   }
-  print2("Enter the flames? [yn] ");
+  print2("Enter the flames? [YN] ");
   if (ynq2()=='y') {
     if (Player.hp == 1) p_death("total incineration");
     else Player.hp = 1;
     dataprint();
-    print1("You feel like you are being incinerated! Jump back? [yn] ");
+    print1("You feel like you are being incinerated! Jump back? [YN] ");
     if (ynq1()=='y')
       print2("Phew! That was close!");
     else {
@@ -562,7 +562,7 @@ void l_water_station()
     print2("The vapor burns despite your immunity to acid!");
     morewait();
   }
-  print1("Enter the fluid? [yn] ");
+  print1("Enter the fluid? [YN] ");
   if (ynq1()=='y') {
     if (Player.hp == 1) p_death("drowning in acid (ick, what a way to go)");
     else Player.hp = 1;
@@ -571,7 +571,7 @@ void l_water_station()
     morewait();
     nprint2("Your lungs burn....");
     morewait();
-    print2("Your body begins to disintegrate.... Leave the pool? [yn] ");
+    print2("Your body begins to disintegrate.... Leave the pool? [YN] ");
     if (ynq2()=='y')
       print2("Phew! That was close!");
     else {
@@ -603,13 +603,13 @@ void l_air_station()
   if (Player.immunity[ELECTRICITY])
     print2("You feel static cling despite your immunity to electricity!");
   morewait();
-  print1("Enter the storm? [yn] ");
+  print1("Enter the storm? [YN] ");
   if (ynq1()=='y') {
     if (Player.hp == 1) p_death("being torn apart and then electrocuted");
     else Player.hp = 1;
     dataprint();
     print1("You are buffeted and burnt by the storm....");
-    print2("You begin to lose consciousness.... Leave the storm? [yn] ");
+    print2("You begin to lose consciousness.... Leave the storm? [YN] ");
     if (ynq1()=='y')
       print2("Phew! That was close!");
     else {
@@ -640,13 +640,13 @@ void l_earth_station()
   if (find_item(&o,THINGID+6,-1))
     print2("A splash of salt water does nothing to dissuade the vines.");
   morewait();
-  print1("Enter the overgrown mire? [yn] ");
+  print1("Enter the overgrown mire? [YN] ");
   if (ynq1()=='y') {
     if (Player.hp == 1) p_death("being eaten alive");
     else Player.hp = 1;
     dataprint();
     print1("You are being dragged into the muck. Suckers bite you....");
-    print2("You're about to be entangled.... Leave the mud? [yn] ");
+    print2("You're about to be entangled.... Leave the mud? [YN] ");
     if (ynq2()=='y')
       print2("Phew! That was close!");
     else {
@@ -704,7 +704,7 @@ void stationcheck()
 void l_void_station()
 {
   int i,something=FALSE;
-  print1("You are at the brink of an endless void. Enter it? [yn] ");
+  print1("You are at the brink of an endless void. Enter it? [YN] ");
   if (ynq()=='y') {
     if (Level->mlist == NULL) {
       print2("You fall forever. Eventually you die of starvation.");
@@ -804,7 +804,7 @@ void l_whirlwind()
 void l_enter_circle()
 {
   print1("You see a translucent stairway before you, leading down.");
-  print2("Take it? [yn] ");
+  print2("Take it? [YN] ");
   if (ynq()=='y')
     change_environment(E_CIRCLE);
 }
@@ -859,7 +859,7 @@ void l_throne()
   pob o;
   int i;
   print1("You have come upon a huge ornately appointed throne!");
-  print2("Sit in it? [yn] ");
+  print2("Sit in it? [YN] ");
   if (ynq1()=='y') {
     if (! find_item(&o,ARTIFACTID+22,-1)) {
       print1("The throne emits an eerie violet-black radiance.");
@@ -954,7 +954,7 @@ void l_escalator()
   print1("You have found an extremely long stairway going straight up.");
   print2("The stairs are grilled steel and the bannister is rubber.");
   morewait();
-  print1("Take the stairway? [yn] ");
+  print1("Take the stairway? [YN] ");
   if (ynq1()=='y') {
     print1("The stairs suddenly start moving with a grind of gears!");
     print2("You are wafted to the surface....");
@@ -964,7 +964,7 @@ void l_escalator()
 
 void l_enter_court()
 {
-  print1("You have found a magical portal! Enter it? [yn] ");
+  print1("You have found a magical portal! Enter it? [YN] ");
   if (ynq1()=='y') {
     if (! gamestatusp(COMPLETED_CASTLE)) {
       if (! gamestatusp(ATTACKED_ORACLE)) {
@@ -988,7 +988,7 @@ void l_chaostone()
   else print2("You find it extremely difficult to approach the stone.");
   morewait();
   clearmsg();
-  print1("Touch it? [yn] ");
+  print1("Touch it? [YN] ");
   if (ynq1()=='y') {
     print1("A sudden flux of energy surrounds you!");
     morewait();
@@ -1008,7 +1008,7 @@ void l_balancestone()
   print2("You feel a sense of balance as you regard it.");
   morewait();
   clearmsg();
-  print1("Touch it? [yn] ");
+  print1("Touch it? [YN] ");
   if (ynq1()=='y') {
     print1("A vortex of mana spins about you!");
     if (abs(Player.alignment) > random_range(50)) {
@@ -1023,7 +1023,7 @@ void l_balancestone()
       drawvision(Player.x,Player.y);
     }
     else {
-      print2("You are being drained of experience! Step back? [yn] ");
+      print2("You are being drained of experience! Step back? [YN] ");
       if (ynq2()=='y') {
 	clearmsg();
 	print1("The vortex calms down, dimishes, and then disappears.");
@@ -1053,7 +1053,7 @@ void l_lawstone()
   else print2("You find the stone extremely distasteful to contemplate.");
   morewait();
   clearmsg();
-  print1("Touch it? [yn] ");
+  print1("Touch it? [YN] ");
   if (ynq()=='y') {
     print1("A matrix of power flows about you!");
     morewait();
@@ -1074,7 +1074,7 @@ void l_voidstone()
   print2("A feeling of nihility emanates from it.");
   morewait();
   clearmsg();
-  print1("Touch it? [yn] ");
+  print1("Touch it? [YN] ");
   if (ynq()=='y') {
     print1("You feel negated.");
     morewait();
@@ -1102,10 +1102,10 @@ void l_sacrificestone()
   print2("On the top surface is an indentation in human shape.");
   morewait();
   print1("You see old rust colored stains in the grain of the stone.");
-  print2("You sense something awakening. Touch the block? [yn] ");
+  print2("You sense something awakening. Touch the block? [YN] ");
   if (ynq2() == 'y') {
     print1("You sense great pain emanating from the ancient altar.");
-    print2("Climb on to the block? [yn] ");
+    print2("Climb on to the block? [YN] ");
     if (ynq2() == 'y') {
       print1("You are stuck fast to the block!");
       print2("You feel your life-force being sucked away!");
@@ -1158,7 +1158,7 @@ void l_mindstone()
   print2("Flashes of irridescent light glint from the object.");
   morewait();
   print1("You feel your attention being drawn by the intricate crystal.");
-  print2("Look away from the interesting phenomenon? [yn] ");
+  print2("Look away from the interesting phenomenon? [YN] ");
   if (ynq2()=='n') {
     print1("Your gaze focuses deeply on the gem....");
     print2("The crystal seems to open up and surround you!");

--- a/mtalk.c
+++ b/mtalk.c
@@ -31,7 +31,7 @@ struct monster *m;
 	}
       }
     }
-    mprint("Do you request a ritual of neutralization? [yn] ");
+    mprint("Do you request a ritual of neutralization? [YN] ");
     if (ynq() == 'y') {
       if (Phase/2 == 6 || Phase/2 == 0) {	/* full or new moon */
 	mprint("\"Unfortunately, I cannot perform a ritual of balance on");
@@ -78,7 +78,7 @@ struct monster *m;
     mprint("The ArchDruid looks at you and cries: 'Unclean! Unclean!'");
     disrupt(Player.x,Player.y,100);
     mprint("This seems to have satiated his desire for vengeance.");
-    mprint("'Have you learned your lesson?' The ArchDruid asks. [yn] ");
+    mprint("'Have you learned your lesson?' The ArchDruid asks. [YN] ");
     if (ynq()) {
       mprint("'I certainly hope so!' says the ArchDruid.");
       for (curr = Level->mlist; curr; curr = curr->next)
@@ -176,7 +176,7 @@ struct monster *m;
 {
   if (m_statusp(m,HOSTILE)) {
     print1("'Surrender in the name of the Law!'");
-    print2("Do it? [yn] ");
+    print2("Do it? [YN] ");
     if (ynq2()=='y') {
       Player.alignment++;
       if (Current_Environment == E_CITY) {
@@ -279,7 +279,7 @@ struct monster *m;
     mprint("for only");
     mlongprint(max(10,4*true_item_value(m->possessions->thing)));
     mprint("Au.");
-    mprint("Want it? [yn] ");
+    mprint("Want it? [YN] ");
     if (ynq()=='y') {
       if (Player.cash < (max(10,4*true_item_value(m->possessions->thing)))) {
 	if (Player.alignment > 10) {
@@ -498,7 +498,7 @@ struct monster *m;
   {
     strcat(Str2," beckons seductively...");
     mprint(Str2);
-    mprint("Flee? [yn] ");
+    mprint("Flee? [YN] ");
     if (ynq()=='y') {
       mprint("You feel stupid.");
     }
@@ -533,7 +533,7 @@ struct monster *m;
   {
     strcat(Str2," beckons seductively...");
     mprint(Str2);
-    mprint("Flee? [yn] ");
+    mprint("Flee? [YN] ");
     if (ynq()=='y') 
       mprint("You feel fortunate....");
     else {
@@ -585,7 +585,7 @@ struct monster *m;
   else if (Current_Environment == Current_Dungeon)
     mprint("The horse shies; maybe he doesn't like the dungeon air....");
   else {
-    mprint("The horse lets you pat his nose. Want to ride him? [yn] ");
+    mprint("The horse lets you pat his nose. Want to ride him? [YN] ");
     if (ynq()=='y') {
       m->hp = -1;
       Level->site[m->x][m->y].creature = NULL;
@@ -617,12 +617,12 @@ struct monster *m;
   if (m->id == SERV_LAW) {
     target = SERV_CHAOS;
     mprint("The Servant of Law pauses in thought for a moment.");
-    mprint("You are asked: Are there any Servants of Chaos hereabouts? [yn] ");
+    mprint("You are asked: Are there any Servants of Chaos hereabouts? [YN] ");
   }
   else {
     target = SERV_LAW;
     mprint("The Servant of Chaos grins mischievously at you.");
-    mprint("You are asked: Are there any Servants of Law hereabouts? [yn] ");
+    mprint("You are asked: Are there any Servants of Law hereabouts? [YN] ");
   }
   if (ynq()=='y') {
     print1("Show me.");
@@ -710,7 +710,7 @@ struct monster *m;
   if (! m_statusp(m,HOSTILE)) {
     if (Current_Environment == E_VILLAGE) {
       mprint("The merchant asks you if you want to buy a horse for 250GP.");
-      mprint("Pay the merchant? [yn] ");
+      mprint("Pay the merchant? [YN] ");
       if (ynq()=='y') {
 	if (Player.cash < 250) 
 	  mprint("The merchant says: 'Come back when you've got the cash!'");

--- a/priest.c
+++ b/priest.c
@@ -36,7 +36,7 @@ void l_altar()
       print1("This oaken altar is ornately engraved with leaves.");
       break;
   }
-  print2("Worship at this altar? [yn] ");
+  print2("Worship at this altar? [YN] ");
   if (ynq2() == 'y') {
     if (Player.rank[PRIESTHOOD] == 0)
       increase_priest_rank(deity);

--- a/scr.c
+++ b/scr.c
@@ -130,20 +130,20 @@ WINDOW *win;
 {
   char p='*'; /* the user's choice; start with something impossible
                * to prevent a loop. */
-  while ((p != 'n') && (p != 'y') && (p != 'q') && (p != ESCAPE) &&
+  while ((p != 'N') && (p != 'Y') && (p != 'Q') && (p != ESCAPE) &&
          (p != EOF) && (p != ' '))
     p = wgetch(win);
   switch (p) {
-    case 'y': wprintw(win,"yes. "); break;
-    case 'n': wprintw(win,"no. "); break;
+    case 'Y': wprintw(win,"yes. "); break;
+    case 'N': wprintw(win,"no. "); break;
     
-    case ESCAPE: p = 'q'; /* fall through to 'q' */
-    case ' ': p = 'q';    /* fall through to 'q' */
-    case 'q': wprintw(win,"quit. "); break;
+    case ESCAPE: p = 'Q'; /* fall through to 'q' */
+    case ' ': p = 'Q';    /* fall through to 'q' */
+    case 'Q': wprintw(win,"quit. "); break;
     default: assert( p == EOF );
     }
   wrefresh(win);
-  return p;
+  return tolower(p);
 }
 
 int ynq()

--- a/site1.c
+++ b/site1.c
@@ -213,7 +213,7 @@ int base,numitems;
     clearmsg();
     print1("I can let you have it for ");
     mlongprint(2*true_item_value(newitem));
-    nprint1("Au. Buy it? [yn] ");
+    nprint1("Au. Buy it? [YN] ");
     if (ynq1() == 'y') {
       if (Player.cash < 2*true_item_value(newitem)) {
 	print2("Why not try again some time you have the cash?");
@@ -239,7 +239,7 @@ void l_club()
   if (! gamestatusp(CLUB_MEMBER)) {
     if (Player.level < 2) print3("Only reknowned adventurers need apply.");
     else {
-      print2("Dues are 100Au. Pay it? [yn] ");
+      print2("Dues are 100Au. Pay it? [YN] ");
       if (ynq2()=='y') {
 	if (Player.cash < 100)
 	  print3("Beat it, or we'll blackball you!");
@@ -603,7 +603,7 @@ void l_commandant()
   int num;
   pob food;
   print1("Commandant Sonder's Rampart-fried Lyzzard partes. Open 24 hrs.");
-  print2("Buy a bucket! Only 5 Au. Make a purchase? [yn] ");
+  print2("Buy a bucket! Only 5 Au. Make a purchase? [YN] ");
   if (ynq2()=='y') {
     clearmsg();
     print1("How many? ");
@@ -630,7 +630,7 @@ void l_commandant()
 void l_diner()
 {
   print1("The Rampart Diner. All you can eat, 25Au.");
-  print2("Place an order? [yn] ");
+  print2("Place an order? [YN] ");
   if (ynq2()=='y') {
     if (Player.cash < 25)
       mprint("TANSTAAFL! Now git!");
@@ -649,7 +649,7 @@ void l_crap()
   if ((hour() < 17) || (hour() > 23))
     print2 ("So sorry, we are closed 'til the morrow...");
   else {
-    print2("May I take your order? [yn] ");
+    print2("May I take your order? [YN] ");
     if (ynq2()=='y') {
       if (Player.cash < 1000)
 	print2("So sorry, you have not the funds for dinner.");
@@ -749,7 +749,7 @@ void l_tavern()
 	  break;
 	case 3:
 	  print1("Riley draws you a shot of his 'special reserve'");
-	  print2("Drink it [yn]?");
+	  print2("Drink it [YN]?");
 	  if (ynq2()=='y') {
 	    if (Player.con < random_range(20)) {
 	      print1("<cough> Quite a kick!");
@@ -830,7 +830,7 @@ void l_alchemist()
 	  clearmsg();
 	  print1("I'll give you ");
 	  mnumprint(obj->basevalue/3);
-	  nprint1("Au for it. Take it? [yn] ");
+	  nprint1("Au for it. Take it? [YN] ");
 	  if (ynq1()=='y') {
 	    Player.cash += (obj->basevalue/3);
 	    conform_lost_objects(1,obj);
@@ -852,7 +852,7 @@ void l_alchemist()
 	  mlevel = Monsters[obj->charge].level;
 	  print1("It'll cost you ");
 	  mnumprint(max(10,obj->basevalue*2));
-	  nprint1("Au for the transformation. Pay it? [yn] ");
+	  nprint1("Au for the transformation. Pay it? [YN] ");
 	  if (ynq1()=='y') {
 	    if (Player.cash < max(10,obj->basevalue*2))
 	      print2("You can't afford it!");
@@ -881,7 +881,7 @@ void l_dpw()
   if (Date - LastDay < 7)
     print2("G'wan! Get a job!");
   else if (Player.cash < 100) {
-    print2("Do you want to go on the dole? [yn] ");
+    print2("Do you want to go on the dole? [YN] ");
     if (ynq2()=='y') {
       print1("Well, ok, but spend it wisely.");
       morewait();
@@ -928,7 +928,7 @@ void l_library()
     }
     morewait();
     while(! done) {
-      print1("Pay the fee? [yn] ");
+      print1("Pay the fee? [YN] ");
       if (ynq1()=='y') {
 	if (Player.cash < fee) {
 	  print2("No payee, No studee.");
@@ -1084,7 +1084,7 @@ void l_pawn_shop()
 	    clearmsg();
 	    print1("The low, low, cost is: ");
 	    mlongprint(Pawnitems[i]->number*true_item_value(Pawnitems[i]));
-	    nprint1(" Buy it? [ynq] ");
+	    nprint1(" Buy it? [YNQ] ");
 	    if (ynq1() == 'y') {
 	      if (Player.cash < 
 		  Pawnitems[i]->number *
@@ -1121,7 +1121,7 @@ void l_pawn_shop()
 	    clearmsg();
 	    print1("You can get ");
 	    mlongprint(item_value(Player.possessions[i]) / 2);
-	    nprint1("Au each. Sell [yn]? ");
+	    nprint1("Au each. Sell [YN]? ");
 	    if (ynq1() == 'y') {
 	      number = getnumber(Player.possessions[i]->number);
 	      if ((number >= Player.possessions[i]->number) &&
@@ -1152,7 +1152,7 @@ void l_pawn_shop()
 	    nprint1(itemid(Player.pack[i]));
 	    nprint1(" for ");
 	    mlongprint(item_value(Player.pack[i])/2);
-	    nprint1("Au each? [yn] ");
+	    nprint1("Au each? [YN] ");
 	    if (ynq1()=='y') {
 	      number = getnumber(Player.pack[i]->number);
 	      if (number > 0) {

--- a/site2.c
+++ b/site2.c
@@ -17,7 +17,7 @@ void l_condo()
     print2("Which are you interested in [r,p, or ESCAPE] ");
     response = mgetc();
     if (response == 'p') {
-      print2("Only 50,000Au. Buy it? [yn] ");
+      print2("Only 50,000Au. Buy it? [YN] ");
       if (ynq2()=='y') {
 	if (Player.cash < 50000) 
 	  print3("No mortgages, buddy.");
@@ -31,7 +31,7 @@ void l_condo()
       }
     }
     else if (response == 'r') {
-      print2("Weekly Rental, 1000Au. Pay for it? [yn] ");
+      print2("Weekly Rental, 1000Au. Pay for it? [YN] ");
       if (ynq2()=='y') {
 	if (Player.cash < 1000)
 	  print2("Hey, pay the rent or out you go....");
@@ -75,7 +75,7 @@ void l_condo()
 	while ((ol != NULL) && (! over)) {
 	  print1("Retrieve ");
 	  nprint1(itemid(ol->thing));
-	  nprint1(" [ynq] ");
+	  nprint1(" [YNQ] ");
 	  response = (char) mcigetc();
 	  if (response == 'y') {
 	    gain_item(ol->thing);
@@ -96,7 +96,7 @@ void l_condo()
       }
       else if (response == 'd') {
 	clearmsg();
-	print1("You sure you want to retire, now? [yn] ");
+	print1("You sure you want to retire, now? [YN] ");
 	if (ynq1() == 'y') {
 	  p_win();
 	}
@@ -337,7 +337,7 @@ void l_adept()
     morewait();
     clearmsg();
   }
-  print2("Enter the mystic portal? [yn] ");
+  print2("Enter the mystic portal? [YN] ");
   if (ynq2()!='y') {
     if (Player.level > 100) {
       print1("The Lords of Destiny spurn your cowardice....");
@@ -454,7 +454,7 @@ void l_vault()
     Level->site[12][56].locchar = WALL;
     morewait();
     clearmsg();
-    print1("Try to crack it? [yn] ");
+    print1("Try to crack it? [YN] ");
     if (ynq1()=='y') {
       if (random_range(100) < Player.rank[THIEVES]*Player.rank[THIEVES]) {
 	print2("The lock clicks open!!!");
@@ -485,7 +485,7 @@ void l_brothel()
   print2("A sign reads `The House of the Eclipse'");
   morewait();
   clearmsg();
-  print1("Try to enter? [yn] ");
+  print1("Try to enter? [YN] ");
   if (ynq1()=='y') {
     menuclear();
     menuprint("a:knock on the door.\n");
@@ -505,7 +505,7 @@ void l_brothel()
 	print2("There is no reponse.");
       else {
 	print1("A window opens in the door.");
-	print2("`500Au, buddy. For the night.' pay it? [yn] ");
+	print2("`500Au, buddy. For the night.' pay it? [YN] ");
 	if (ynq2()=='y') {
 	  if (Player.cash < 500) {
 	    print1("`What, no roll?!'");
@@ -809,7 +809,7 @@ void l_oracle()
   char response;
   if (gamestatusp(ATTACKED_ORACLE) && (! gamestatusp(COMPLETED_ASTRAL))) {
     print1("You come before a blue crystal dais. You see a broken mirror.");
-    print2("Look in the mirror? [yn] ");
+    print2("Look in the mirror? [YN] ");
     if (ynq2()=='y') {
       print1("A strange force rips you from your place....");
       Player.hp = 1;
@@ -829,7 +829,7 @@ void l_oracle()
       print2("You notice a robed figure in front of you....");
       morewait();
       print1("The oracle doffs her cowl. Her eyes glitter with blue fire!");
-      print2("Attack her? [yn] ");
+      print2("Attack her? [YN] ");
       if (ynq2() == 'y') {
 	setgamestatus(ATTACKED_ORACLE);
 	print1("The oracle deftly avoids your attack.");
@@ -852,7 +852,7 @@ void l_oracle()
 	else if (!gamestatusp(COMPLETED_ASTRAL)) {
 	  morewait();
 	  print1("'Journey to the Astral Plane and meet the Gods' servants.'");
-	  print2("The oracle holds out her hand. Do you take it? [yn] ");
+	  print2("The oracle holds out her hand. Do you take it? [YN] ");
 	  if (ynq2()=='y') {
 	    print1("'Beware: Only the Star Gem can escape the Astral Plane.'");
 	    print2("A magic portal opens behind the oracle. She leads you");
@@ -891,21 +891,21 @@ void l_oracle()
 
 void l_mansion()
 {
-  print1("Enter the mansion? [yn] ");
+  print1("Enter the mansion? [YN] ");
   if (ynq1()=='y')
     change_environment(E_MANSION);
 }
 
 void l_house()
 {
-  print1("Enter the house? [yn] ");
+  print1("Enter the house? [YN] ");
   if (ynq1()=='y')
     change_environment(E_HOUSE);
 }
 
 void l_hovel()
 {
-  print1("Enter the hovel? [yn] ");
+  print1("Enter the hovel? [YN] ");
   if (ynq1()=='y')
     change_environment(E_HOVEL);
 }
@@ -992,7 +992,7 @@ void l_cartographer()
 {
   int i,j,x,y;
   print1("Ye Olde Mappe Shoppe.");
-  print2("Map of the local area: 500Au. Buy it? [yn] ");
+  print2("Map of the local area: 500Au. Buy it? [YN] ");
   if (ynq2()=='y') {
     if (Player.cash < 500) 
       print3("Cursed be cheapskates! May you never find an aid station....");
@@ -1027,7 +1027,7 @@ void l_cartographer()
 void l_charity()
 {
   long donation;
-  print2("'Greetings, friend. Do you wish to make a donation?' [yn] ");
+  print2("'Greetings, friend. Do you wish to make a donation?' [YN] ");
   if (ynq2()!='y') 
     print3("'Pinchpurse!'");
   else {

--- a/spell.c
+++ b/spell.c
@@ -261,7 +261,7 @@ void s_ritual()
 	  mprint("A storm of mana coaelesces around you.");
 	  mprint("You are buffeted by bursts of random magic.");
 	  p_damage(random_range(Player.pow),UNSTOPPABLE,"high magic");
-	  mprint("Continue ritual? Could be dangerous.... [yn] ");
+	  mprint("Continue ritual? Could be dangerous.... [YN] ");
 	  if (ynq()=='y') s_wish();
 	  else mprint("The mana fades away to nothingness.");
 	  x = Player.x;

--- a/util.c
+++ b/util.c
@@ -652,10 +652,10 @@ char *prefix,*s;
 int confirmation()
 {
   switch(random_range(4)) {
-  case 0:  mprint("Are you sure? [yn] "); break;
-  case 1:  mprint("Certain about that? [yn] "); break;
-  case 2:  mprint("Do you really mean it? [yn] "); break;
-  case 3:  mprint("Confirm that, would you? [yn] "); break;
+  case 0:  mprint("Are you sure? [YN] "); break;
+  case 1:  mprint("Certain about that? [YN] "); break;
+  case 2:  mprint("Do you really mean it? [YN] "); break;
+  case 3:  mprint("Confirm that, would you? [YN] "); break;
   }
   return(ynq()=='y');
 }


### PR DESCRIPTION
Prevent accidental deaths/selection due to input overlap between option selection y/n/q with movement (vi) keys by forcing capital YNQ for options.