### PR TITLE
Added unistd.h & (u)time.h to prevent warnings

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -302,6 +302,8 @@ static char rcs_ident[] = "$Header: /home/wtanksle/cvs/omega/compress.c,v 1.2 19
 #ifdef notdef
 #include <sys/ioctl.h>
 #endif
+#include <unistd.h>
+#include <utime.h>
 
 int n_bits;				/* number of bits/code */
 int maxbits = BITS;			/* user settable max # bits/code */

--- a/defs.h
+++ b/defs.h
@@ -1612,3 +1612,6 @@ typedef oltype *pol;
 #ifdef SAVE_LEVELS
 plv msdos_changelevel();
 #endif
+
+#include <unistd.h>
+#include <time.h>


### PR DESCRIPTION
Prevents all currently existing implicit function declaration warnings from functions defined in standard libraries.