### PR TITLE
Discovered city

### DIFF
--- a/city.c
+++ b/city.c
@@ -546,6 +546,7 @@ int i,j,populate;
   case 'O':
     Level->site[i][j].locchar = OPEN_DOOR;
     Level->site[i][j].p_locf = L_ORACLE;
+    CitySiteList[L_ORACLE-CITYSITEBASE][0] = FALSE;
     CitySiteList[L_ORACLE-CITYSITEBASE][1] = i;
     CitySiteList[L_ORACLE-CITYSITEBASE][2] = j;
     break;

--- a/omega.c
+++ b/omega.c
@@ -419,7 +419,7 @@ void init_world()
     level_seed[env] = RANDFUNCTION();
   load_country();
   for(i=0;i<NUMCITYSITES;i++) 
-    CitySiteList[i][0] = FALSE;
+    CitySiteList[i][0] = TRUE;
   load_city(TRUE);
   WIDTH = 64;
   LENGTH = 64;


### PR DESCRIPTION
Site locations are always known in the city. This allows for "fast travel" within the city without actually stepping on the location first. It can place the player on top of the door for Thieves Guild & Brothel even if it is closed, but I do not consider this an issue because it is always unlocked, and can be opened at any time. This happens anyway if the player had discovered either location and closed the door before using the "fast travel" feature.