### PR TITLE
Resolve linker input unused warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,7 @@ CFLAGS += \
   -fno-strict-aliasing  \
   -DBSD \
   -DOMEGALIB=\"${LIBDIR}/\"  \
-  -DSAVEDIR=\"${SAVEDIR}/\" \
-  -Wl,-rpath=/usr/local/lib
+  -DSAVEDIR=\"${SAVEDIR}/\"
 
 #CFLAGS = -DSYSV -O
 # I also had to define -cckr (K&R style C) for system V


### PR DESCRIPTION
Remove -Wl,-rpath=/usr/local/lib from CFLAGS. This was inherited from the FreeBSD Ports build environment and is not required.